### PR TITLE
Don't skip the opcode after a stop

### DIFF
--- a/data/languages/sm83_instructions.sinc
+++ b/data/languages/sm83_instructions.sinc
@@ -429,8 +429,6 @@
 
 :STOP is op0_8=0x10 {
   stop();
-  PC = PC + 1;
-  goto [PC];
 }
 
 :DI is op0_8=0xf3 {


### PR DESCRIPTION
stop is a one byte opcode, but due to a bug should always be
followed by a nop, as the byte following a stop is read twice

Since it's possible to encounter a broken stop the opcode
following it should not be skipped

ghidra also seems to think stop is a jump table for some reason