### PR TITLE
Absolute offset in comment area of extra ROM banks

### DIFF
--- a/src/main/java/fi/gekkio/ghidraboy/GameBoyLoader.java
+++ b/src/main/java/fi/gekkio/ghidraboy/GameBoyLoader.java
@@ -201,7 +201,7 @@ public class GameBoyLoader extends AbstractProgramLoader {
                     var offset = 0x4000;
                     var bank = 1;
                     while (offset < rom.getSize()) {
-                        createInitializedBlock(program, true, "rom" + bank, romX, rom, offset, 0x4000, "", getName(), true, false, true, log);
+                        createInitializedBlock(program, true, "rom" + bank, romX, rom, offset, 0x4000, "Offset " + offset + "in ROM file", getName(), true, false, true, log);
                         offset += 0x4000;
                         bank += 1;
                     }


### PR DESCRIPTION
For use with other tools (i.e. YYCHR), so you have reference points for the absolute location in the source ROM file.