### PR TITLE
Use separate registers for flags

### DIFF
--- a/data/languages/sm83.sinc
+++ b/data/languages/sm83.sinc
@@ -20,11 +20,18 @@ define space register type=register_space size=1;
 define register offset=0x00 size=1 [ F A C B E D L H ];
 define register offset=0x00 size=2 [ AF  BC  DE  HL ];
 define register offset=0x08 size=2 [ PC  SP  ];
+define register offset=0x10 size=1 [ C_FLAG H_FLAG N_FLAG Z_FLAG ];
 
-@define C_flag "F[4,1]"
-@define H_flag "F[5,1]"
-@define N_flag "F[6,1]"
-@define Z_flag "F[7,1]"
+macro packflags(tmp) {
+  tmp = (0x80 * Z_FLAG&1) | (0x40 * N_FLAG&1) | (0x20 * H_FLAG&1) | (0x10 * C_FLAG&1);
+}
+
+macro unpackflags(tmp) {
+  Z_FLAG = (tmp & 0x80) != 0;
+  N_FLAG = (tmp & 0x40) != 0;
+  H_FLAG = (tmp & 0x20) != 0;
+  C_FLAG = (tmp & 0x10) != 0;
+}
 
 define token opcode (8)
   op0_8       = (0,7)
@@ -57,20 +64,18 @@ attach variables [ sregpair4_2 dregpair4_2 ] [ BC DE HL SP ];
 attach variables [ qregpair4_2 ] [ BC DE HL AF ];
 
 cc: "NZ" is op3_2=0b00 {
-  local c:1 = ($(Z_flag) == 0);
+  local c:1 = !Z_FLAG;
   export c;
 }
 cc: "Z"  is op3_2=0b01 {
-  local c:1 = $(Z_flag);
-  export c;
+  export Z_FLAG;
 }
 cc: "NC" is op3_2=0b10 {
-  local c:1 = ($(C_flag) == 0);
+  local c:1 = !C_FLAG;
   export c;
 }
 cc: "C"  is op3_2=0b11 {
-  local c:1 = $(C_flag);
-  export c;
+  export C_FLAG;
 }
 
 Addr16: imm16 is imm16 {
@@ -138,98 +143,98 @@ macro pop16(ret16) {
 macro aluAdd(op8) {
   # TODO: double-check flags
   local tmp:1 = A + op8;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = (((A & 0xf) + (op8 & 0xf)) & 0x10) != 0;
-  $(C_flag) = carry(A, op8);
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = (((A & 0xf) + (op8 & 0xf)) & 0x10) != 0;
+  C_FLAG = carry(A, op8);
   A = tmp;
 }
 
 macro aluAdc(op8) {
   # TODO: double-check flags
-  local cy = $(C_flag);
+  local cy = C_FLAG;
   local tmp:1 = A + op8;
-  $(N_flag) = 0;
-  $(H_flag) = (((A & 0xf) + (op8 & 0xf) + cy) & 0x10) != 0;
-  $(C_flag) = carry(A, op8);
+  N_FLAG = 0;
+  H_FLAG = (((A & 0xf) + (op8 & 0xf) + cy) & 0x10) != 0;
+  C_FLAG = carry(A, op8);
   A = tmp + cy;
-  $(Z_flag) = (A == 0);
-  $(C_flag) = $(C_flag) || carry(tmp, cy);
+  Z_FLAG = (A == 0);
+  C_FLAG = C_FLAG || carry(tmp, cy);
 }
 
 macro aluSub(op8) {
   # TODO: double-check flags
   local tmp:1 = A - op8;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 1;
-  $(H_flag) = (((A & 0xf) - (op8 & 0xf)) & 0x10) != 0;
-  $(C_flag) = A < op8;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 1;
+  H_FLAG = (((A & 0xf) - (op8 & 0xf)) & 0x10) != 0;
+  C_FLAG = A < op8;
   A = tmp;
 }
 
 macro aluSbc(op8) {
   # TODO: double-check flags
-  local cy = $(C_flag);
+  local cy = C_FLAG;
   local tmp:1 = A - op8;
-  $(N_flag) = 1;
-  $(H_flag) = (((A & 0xf) - (op8 & 0xf) - cy) & 0x10) != 0;
-  $(C_flag) = A < op8;
+  N_FLAG = 1;
+  H_FLAG = (((A & 0xf) - (op8 & 0xf) - cy) & 0x10) != 0;
+  C_FLAG = A < op8;
   A = tmp - cy;
-  $(Z_flag) = (A == 0);
-  $(C_flag) = $(C_flag) || (tmp < cy);
+  Z_FLAG = (A == 0);
+  C_FLAG = C_FLAG || (tmp < cy);
 }
 
 macro aluAnd(op8) {
   # TODO: double-check flags
   A = A & op8;
-  $(Z_flag) = (A == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 1;
-  $(C_flag) = 0;
+  Z_FLAG = (A == 0);
+  N_FLAG = 0;
+  H_FLAG = 1;
+  C_FLAG = 0;
 }
 
 macro aluXor(op8) {
   # TODO: double-check flags
   A = A ^ op8;
-  $(Z_flag) = (A == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = 0;
+  Z_FLAG = (A == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = 0;
 }
 
 macro aluOr(op8) {
   # TODO: double-check flags
   A = A | op8;
-  $(Z_flag) = (A == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = 0;
+  Z_FLAG = (A == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = 0;
 }
 
 macro aluCp(op8) {
   # TODO: double-check flags
   local tmp:1 = A - op8;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 1;
-  $(H_flag) = (((A & 0xf) - (op8 & 0xf)) & 0x10) != 0;
-  $(C_flag) = A < op8;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 1;
+  H_FLAG = (((A & 0xf) - (op8 & 0xf)) & 0x10) != 0;
+  C_FLAG = A < op8;
 }
 
 macro aluInc(op8) {
   # TODO: double-check flags
   local tmp:1 = op8 + 1;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = ((op8 & 0xf) == 0xf);
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = ((op8 & 0xf) == 0xf);
   op8 = tmp;
 }
 
 macro aluDec(op8) {
   # TODO: double-check flags
   local tmp:1 = op8 - 1;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 1;
-  $(H_flag) = ((op8 & 0xf) == 0);
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 1;
+  H_FLAG = ((op8 & 0xf) == 0);
   op8 = tmp;
 }
 
@@ -237,10 +242,10 @@ macro aluRlc(op8) {
   # TODO: double-check flags
   local co:1 = (op8 >> 7);
   local tmp:1 = (op8 << 1) | co;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
@@ -248,32 +253,32 @@ macro aluRrc(op8) {
   # TODO: double-check flags
   local co:1 = op8 & 1;
   local tmp:1 = (op8 >> 1) | (co << 7);
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
 macro aluRl(op8) {
   # TODO: double-check flags
   local co:1 = (op8 >> 7);
-  local tmp:1 = (op8 << 1) | $(C_flag);
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  local tmp:1 = (op8 << 1) | C_FLAG;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
 macro aluRr(op8) {
   # TODO: double-check flags
   local co:1 = op8 & 1;
-  local tmp:1 = (op8 >> 1) | ($(C_flag) << 7);
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  local tmp:1 = (op8 >> 1) | (C_FLAG << 7);
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
@@ -281,10 +286,10 @@ macro aluSla(op8) {
   # TODO: double-check flags
   local co:1 = op8 >> 7;
   local tmp:1 = op8 << 1;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
@@ -292,20 +297,20 @@ macro aluSra(op8) {
   # TODO: double-check flags
   local co:1 = op8 & 1;
   local tmp:1 = op8 s>> 1;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
 macro aluSwap(op8) {
   # TODO: double-check flags
   local tmp:1 = (op8 >> 4) | (op8 << 4);
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = 0;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = 0;
   op8 = tmp;
 }
 
@@ -313,10 +318,10 @@ macro aluSrl(op8) {
   # TODO: double-check flags
   local co:1 = op8 & 1;
   local tmp:1 = op8 >> 1;
-  $(Z_flag) = (tmp == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = (tmp == 0);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
   op8 = tmp;
 }
 
@@ -324,9 +329,9 @@ macro aluBit(bit, op8) {
   # TODO: double-check flags
   local mask:1 = (1 << bit);
   local tmp:1 = op8;
-  $(Z_flag) = ((tmp & mask) == 0);
-  $(N_flag) = 0;
-  $(H_flag) = 1;
+  Z_FLAG = ((tmp & mask) == 0);
+  N_FLAG = 0;
+  H_FLAG = 1;
 }
 
 macro aluRes(bit, op8) {

--- a/data/languages/sm83_instructions.sinc
+++ b/data/languages/sm83_instructions.sinc
@@ -220,40 +220,40 @@
   # TODO: double-check flags
   local co:1 = (A >> 7);
   A = (A << 1) | co;
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
 }
 
 :RLA is op0_8=0x17 {
   # TODO: double-check flags
   local co:1 = (A >> 7);
-  A = (A << 1) | $(C_flag);
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  A = (A << 1) | C_FLAG;
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
 }
 
 :RRCA is op0_8=0x0f {
   # TODO: double-check flags
   local co:1 = A & 1;
   A = (A >> 1) | (co << 7);
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
 }
 
 :RRA is op0_8=0x1f {
   # TODO: double-check flags
   local co:1 = A & 1;
-  A = (A >> 1) | ($(C_flag) << 7);
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = co;
+  A = (A >> 1) | (C_FLAG << 7);
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = co;
 }
 
 :RLC reg0_3 is op0_8=0xcb; op6_2=0b00 & op3_3=0b000 & reg0_3 {
@@ -442,15 +442,15 @@
 }
 
 :CCF is op0_8=0x3f {
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = !$(C_flag);
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = !C_FLAG;
 }
 
 :SCF is op0_8=0x37 {
-  $(N_flag) = 0;
-  $(H_flag) = 0;
-  $(C_flag) = 1;
+  N_FLAG = 0;
+  H_FLAG = 0;
+  C_FLAG = 1;
 }
 
 :NOP is op0_8=0x00 {
@@ -462,8 +462,8 @@
 
 :CPL is op0_8=0x2f {
   A = ~A;
-  $(N_flag) = 1;
-  $(H_flag) = 1;
+  N_FLAG = 1;
+  H_FLAG = 1;
 }
 
 # 16-bit loads
@@ -483,10 +483,10 @@
 :LD HL, SP+simm8 is op0_8=0xf8 & HL & SP; simm8 {
   # TODO: double-check flags
   local tmp:2 = SP + simm8;
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = (((SP:1 & 0xf) + (simm8 & 0xf)) & 0x10) != 0;
-  $(C_flag) = carry(SP:1, simm8);
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = (((SP:1 & 0xf) + (simm8 & 0xf)) & 0x10) != 0;
+  C_FLAG = carry(SP:1, simm8);
   HL = tmp;
 }
 
@@ -495,15 +495,25 @@
 ] {
   # TODO: double-check flags
   local tmp:2 = SP + simm8;
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = (((SP:1 & 0xf) + (simm8 & 0xf)) & 0x10) != 0;
-  $(C_flag) = carry(SP:1, simm8);
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = (((SP:1 & 0xf) + (simm8 & 0xf)) & 0x10) != 0;
+  C_FLAG = carry(SP:1, simm8);
   HL = tmp;
+}
+
+:PUSH qregpair4_2 is op6_2=0b11 & qregpair4_2 & op0_4=0b0101 & qregpair4_2=AF {
+  packflags(F);
+  push16(qregpair4_2);
 }
 
 :PUSH qregpair4_2 is op6_2=0b11 & qregpair4_2 & op0_4=0b0101 {
   push16(qregpair4_2);
+}
+
+:POP qregpair4_2 is op6_2=0b11 & qregpair4_2 & op0_4=0b0001 & qregpair4_2=AF {
+  pop16(AF);
+  unpackflags(F);
 }
 
 :POP qregpair4_2 is op6_2=0b11 & qregpair4_2 & op0_4=0b0001 {
@@ -515,19 +525,19 @@
 :ADD HL, sregpair4_2 is op6_2=0b00 & sregpair4_2 & op0_4=0b1001 & HL {
   # TODO: double-check flags
   local tmp:2 = HL + sregpair4_2;
-  $(N_flag) = 0;
-  $(H_flag) = (((HL & 0xfff) + (sregpair4_2 & 0xfff)) & 0x1000) != 0;
-  $(C_flag) = carry(HL, sregpair4_2);
+  N_FLAG = 0;
+  H_FLAG = (((HL & 0xfff) + (sregpair4_2 & 0xfff)) & 0x1000) != 0;
+  C_FLAG = carry(HL, sregpair4_2);
   HL = tmp;
 }
 
 :ADD SP, simm8 is op0_8=0xe8 & SP; simm8 {
   # TODO: double-check flags
   local tmp:2 = SP + simm8;
-  $(Z_flag) = 0;
-  $(N_flag) = 0;
-  $(H_flag) = (((SP:1 & 0xf) + (simm8 & 0xf)) & 0x10) != 0;
-  $(C_flag) = carry(SP:1, simm8);
+  Z_FLAG = 0;
+  N_FLAG = 0;
+  H_FLAG = (((SP:1 & 0xf) + (simm8 & 0xf)) & 0x10) != 0;
+  C_FLAG = carry(SP:1, simm8);
   SP = tmp;
 }
 


### PR DESCRIPTION
Prevents ghidra from decompiling things as (char)(A != B) < 0x0

Based off Ghidra's x86 sla